### PR TITLE
Register with LineRegistry

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -22,7 +22,10 @@ const schema: Schema<ConfigOptions> = {
   metadataUri: {
     type: 'string'
   },
-  registry: {
+  lineRegistry: {
+    type: 'string'
+  },
+  serviceProviderRegistry: {
     type: 'string'
   },
   serviceProviderId: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,8 @@ export interface ConfigOptions {
   login?: LoginTokens;
   salt?: string;
   metadataUri?: string;
-  registry?: string;
+  serviceProviderRegistry?: string;
+  lineRegistry?: string;
   serviceProviderId?: string;
 }
 


### PR DESCRIPTION
This PR adds missing functionality to ensure that the `facilityId` is registered with the `LineRegistry` (which essentially means it's an agreement to abide by the 'terms', ie. the 'Stays' contract).