### PR TITLE
fix: 🐛 wait for confirmation

### DIFF
--- a/src/api/serviceProvider.ts
+++ b/src/api/serviceProvider.ts
@@ -136,13 +136,16 @@ export const registerServiceProvider = async (
       options
     );
 
-    // wait for 2 confirmations
-    await tx.wait(2)
+    // wait for confirmation
+    await tx.wait(1);
   }
 
   if(!await lineRegistryContract.can(utils.formatBytes32String('stays'), serviceProviderId)) {
     // Register (agree) to the terms in the LineRegistry
-    await lineRegistryContract.register(utils.formatBytes32String('stays'), serviceProviderId)
+    const tx = await lineRegistryContract.register(utils.formatBytes32String('stays'), serviceProviderId);
+
+    // wait for confirmation
+    await tx.wait(1);
   }
 
   return serviceProviderId;
@@ -156,12 +159,15 @@ export const updateServiceProvider = async (
   options?: CallOverrides
 ): Promise<void> => {
   spinnerCallback('Updating the dataURI of the service provider...');
-  await contract['file(bytes32,bytes32,string)'](
+  const tx = await contract['file(bytes32,bytes32,string)'](
     serviceProviderId,
     utils.formatBytes32String('dataURI'),
     metadataUri,
     options
   );
+
+  // don't exit until transaction is confirmed.
+  await tx.wait(1);
 };
 
 export const serviceProviderController: ActionController = async (


### PR DESCRIPTION
This PR by default will wait for at least 1 transaction confirmation before exiting when updating / registering a service provider. This ensures that when `lpms-cli` exits, chainstate is as the user would expect.

Without this, it may be that if someone attempts a quick start of the `facility` on `lpms-server` after enrolling, the `LineRegistry` transaction may not have confirmed, in which case this would throw a `404` on `lpms-server` when it checks that the `facility` is a member of the `line` in `LineRegistry`.